### PR TITLE
Improving typescript try/catch default coloring.

### DIFF
--- a/lua/nord/groups.lua
+++ b/lua/nord/groups.lua
@@ -455,6 +455,7 @@ M.setup = function()
     typescriptIndexExpr = { link = "NordFgArcticBlue9" },
     -- typescriptProperty = { link = "NordFgArcticBlue9" },
     typescriptUnaryOp = { link = "NordFgArcticBlue9" },
+    typescriptExceptions = { link = "NordFgArcticBlue9" },
 
     vimAugroup = { link = "NordFgGreenBlue7" },
     vimMapRhs = { link = "NordFgGreenBlue7" },


### PR DESCRIPTION
Prior to change: 
![image](https://github.com/hoelter/nord.nvim/assets/14192678/83e29cd4-6f57-4eee-8d5c-b670820d6574)


With change:
![image](https://github.com/hoelter/nord.nvim/assets/14192678/7ceff5c1-2082-4f5c-86d9-cb3b06be0e24)

With change and treesitter active:
![image](https://github.com/hoelter/nord.nvim/assets/14192678/f1b0448f-03c3-4ade-be99-fedac9d44493)

